### PR TITLE
cap-containers: added cap_map support with skip lists

### DIFF
--- a/cap-containers/list.h
+++ b/cap-containers/list.h
@@ -60,13 +60,17 @@ static cap_list *cap_list_init();
 
 // Lookup & Update:
 /**
- * Iterate the list and find the first occurance of the element which matches the predicate-function
+ * Iterate the list and find the first occurance of the element which matches
+ * the predicate-function
  *
  * @param list cap_list container
- * @param predicate_fn Predicate function where we will pass the elements(NULL is never passed into the predicate function)
- * @return Returns the element which matches the first occurance of the predicate, if none matches, NULL is returned
+ * @param predicate_fn Predicate function where we will pass the elements(NULL
+ * is never passed into the predicate function)
+ * @return Returns the element which matches the first occurance of the
+ * predicate, if none matches, NULL is returned
  */
-static void *cap_list_find_if(const cap_list *list, bool (*predicate_fn)(void *));
+static void *cap_list_find_if(const cap_list *list,
+			      bool (*predicate_fn)(void *));
 /**
  * Push an element at the front of the cap_list container
  *
@@ -87,48 +91,57 @@ static bool cap_list_push_back(cap_list *list, void *item);
  * Pop the element at the front of the cap_list container
  *
  * @param list cap_list container
- * @return Returns the element if operation is success, returns NULL if cap_list container is empty
+ * @return Returns the element if operation is success, returns NULL if cap_list
+ * container is empty
  */
 static void *cap_list_pop_front(cap_list *list);
 /**
  * Pop the element at the end of the cap_list container
  *
  * @param list cap_list container
- * @return Returns the element if operation is success, returns NULL if cap_list container is empty
+ * @return Returns the element if operation is success, returns NULL if cap_list
+ * container is empty
  */
 static void *cap_list_pop_back(cap_list *);
 /**
  * Gives access to the front of the cap_list without modifying the container
  *
  * @param list cap_list container
- * @return Gives access to the front element of the cap_list container, returns NULL if the container is empty
+ * @return Gives access to the front element of the cap_list container, returns
+ * NULL if the container is empty
  */
 static void *cap_list_front(const cap_list *list);
 /**
  * Gives access to the end of the cap_list without modifying the container
  *
  * @param list cap_list container
- * @return Gives access to the element at the back of the cap_list container, returns NULL if the container is empty
+ * @return Gives access to the element at the back of the cap_list container,
+ * returns NULL if the container is empty
  */
 static void *cap_list_back(const cap_list *list);
 /**
- * Iterates the cap_list container and remove all occurance of the element which matches the predicate function
+ * Iterates the cap_list container and remove all occurance of the element which
+ * matches the predicate function
  *
  * @param list cap_list container
- * @param predicate_fn Predicate function which we pass the elements into, implementation ensures that predicate_fn will never gets a NULL as param.
- * @return True if any element is removed, False if the given predicate_fn does not match any of the elements
+ * @param predicate_fn Predicate function which we pass the elements into,
+ * implementation ensures that predicate_fn will never gets a NULL as param.
+ * @return True if any element is removed, False if the given predicate_fn does
+ * not match any of the elements
  */
 static bool cap_list_remove_if(cap_list *list, bool (*predicate_fn)(void *));
 
 // Memory:
 /**
- * Frees the cap_list container object and also frees the elements which it contains(assuming the elements are dynamically allocated)
+ * Frees the cap_list container object and also frees the elements which it
+ * contains(assuming the elements are dynamically allocated)
  *
  * @param list cap_list container
  */
 static void cap_list_deep_free(cap_list *list);
 /**
- * Frees only the cap_list container object and does not touch the elements which it contains
+ * Frees only the cap_list container object and does not touch the elements
+ * which it contains
  *
  * @param list cap_list container
  */

--- a/cap-containers/map.h
+++ b/cap-containers/map.h
@@ -22,13 +22,11 @@
 #ifndef CAP_MAP_H
 #define CAP_MAP_H
 #include <assert.h>
-#include <cstdlib>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
 #define CAP_GENERIC_TYPE unsigned char
 #define CAP_GENERIC_TYPE_PTR CAP_GENERIC_TYPE *
 #define CAP_ALLOCATOR(type, number_of_elements)                                \
@@ -122,7 +120,7 @@ static int cap_map_insert(cap_map *map, void *key, void *value) {
 
 static void *cap_map_find(cap_map *map, void *key) {
 	assert(map != NULL && key != NULL);
-	cap_map *current_node;
+	cap_map *current_node = map;
 	int current_level = map->_height - 1;
 	while (current_level >= 0) {
 		if (current_node->_forward[current_level] == NULL) {

--- a/cap-containers/map.h
+++ b/cap-containers/map.h
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 #define CAP_GENERIC_TYPE unsigned char
 #define CAP_GENERIC_TYPE_PTR CAP_GENERIC_TYPE *
 #define CAP_ALLOCATOR(type, number_of_elements)                                \
@@ -44,23 +45,110 @@ typedef struct cap_map {
 } cap_map;
 
 bool _cap_map_is_seeded = false;
+#endif // !DOXYGEN_SHOULD_SKIP_THIS
 
+/**
+ * Initilize a cap_map container object
+ *
+ * @return Newly allocated pointer to the head
+ */
 static cap_map *cap_map_init(size_t key_size,
 			     int (*compare_fn)(void *, void *));
+/**
+ * Insert a key-value pair onto the cap_map container.
+ *
+ * The container doesn't manage the life time of the given pointers, neither the
+ * Key's pointer nor the Value's one. Use must explicitly free() the pointer
+ * when they don't need it. They must remove the pointer before calling free()
+ * on it, if not done so, the container will hold a pointer which is already
+ * freed
+ *
+ * @param map cap_map container
+ * @param key Pointer to the key
+ * @param value Pointer to the value
+ * @return Returns 0 if the operation is success, or else returns -1 is there
+ * was a memory allocation error
+ */
 static int cap_map_insert(cap_map *map, void *key, void *value);
+/**
+ * Find an element on the cap_map container
+ *
+ * @param map cap_map container
+ * @param key Key for which we need to find the value.
+ * @return Returns the pointer to the element, if the element with key is not
+ * found, it returns NULL
+ */
 static void *cap_map_find(cap_map *map, void *key);
+/**
+ * Check if an item with the given key exists within the cap_map container.
+ *
+ * @param map cap_map container
+ * @param key Key for which we need to see if the elements exists.
+ * @return True if the item does exists, or else returns false if not
+ */
 static bool cap_map_contains(cap_map *map, void *key);
+/**
+ * Get the function pointer to the handle which the cap_map container uses to
+ * compare two keys
+ *
+ * @param map cap_map container
+ * @return Function pointer to the handle which compares two keys. The one given
+ * during the initilization of the cap_map
+ */
 static int (*cap_map_compare_fn(cap_map *map))(void *, void *);
+/**
+ * Get the current size of the container i.e number of elements
+ *
+ * @param map cap_map container
+ * @return size of the container.
+ */
 static size_t cap_map_size(cap_map *map);
+/**
+ * Remove an element which is mapped to the given key from the container
+ *
+ * @param map cap_map container
+ * @return 0 if the key is found and the element is removed successfully.
+ * Returns -1 if the element is not found.
+ */
 static int cap_map_remove(cap_map *map, void *key);
+/**
+ * Get the max height of the cap_map
+ *
+ * The returned value is the max height of the skip list, which the cap_map
+ * internally uses as the underlying implementation
+ *
+ * @param map cap_map container
+ * @return Max height of the container's implementation
+ */
 static int cap_map_height(cap_map *map);
+/**
+ * Free the cap_map container. It doesn't touch the key or value's underlying
+ * memory. Only frees the memory which the container owns.
+ *
+ * @param map cap_map container
+ */
 static void cap_map_free(cap_map *map);
+/**
+ * Free the cap_map container and also the underlying memory of the values. When
+ * we free the node's memory, we also call free() on the values(assuming that
+ * the values are dynamically allocated)
+ *
+ * @param map cap_map container
+ */
 static void cap_map_deep_free(cap_map *map);
+/**
+ * Check if the cap_map is empry or not
+ *
+ * @param map cap_map container
+ * @return True if the container is empty, False if not.
+ */
 static bool cap_map_empty(cap_map *map);
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 static int _cap_map_get_rand_level(int max_number);
 static void _cap_map_free_node(cap_map *map);
 static void _cap_map_deep_free_node(cap_map *map);
+#endif // !DOXYGEN_SHOULD_SKIP_THIS
 
 static cap_map *cap_map_init(size_t key_size,
 			     int (*compare_fn)(void *, void *)) {

--- a/cap-containers/map.h
+++ b/cap-containers/map.h
@@ -1,0 +1,245 @@
+// cap-containers for pure C
+// Copyright © 2021 Harsath <harsath@tuta.io>
+// The software is licensed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+// OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#ifndef CAP_MAP_H
+#define CAP_MAP_H
+#include <assert.h>
+#include <cstdlib>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+#define CAP_GENERIC_TYPE unsigned char
+#define CAP_GENERIC_TYPE_PTR CAP_GENERIC_TYPE *
+#define CAP_ALLOCATOR(type, number_of_elements)                                \
+	calloc(number_of_elements, sizeof(type))
+#define CAP_MAP_MAX_SKIPLIST_SIZE 10
+
+typedef struct cap_map {
+	CAP_GENERIC_TYPE_PTR _key;
+	size_t _key_size;
+	void *_value;
+	int _height;
+	size_t _size;
+	int (*_compare_fn)(void *key_one, void *key_two);
+	struct cap_map *_forward[CAP_MAP_MAX_SKIPLIST_SIZE];
+} cap_map;
+
+bool _cap_map_is_seeded = false;
+
+static cap_map *cap_map_init(size_t key_size,
+			     int (*compare_fn)(void *, void *));
+static int cap_map_insert(cap_map *map, void *key, void *value);
+static void *cap_map_find(cap_map *map, void *key);
+static bool cap_map_contains(cap_map *map, void *key);
+static int (*cap_map_compare_fn(cap_map *map))(void *, void *);
+static size_t cap_map_size(cap_map *map);
+static int cap_map_remove(cap_map *map, void *key);
+static int cap_map_height(cap_map *map);
+static void cap_map_free(cap_map *map);
+static void cap_map_deep_free(cap_map *map);
+static bool cap_map_empty(cap_map *map);
+
+static int _cap_map_get_rand_level(int max_number);
+static void _cap_map_free_node(cap_map *map);
+static void _cap_map_deep_free_node(cap_map *map);
+
+static cap_map *cap_map_init(size_t key_size,
+			     int (*compare_fn)(void *, void *)) {
+	assert(compare_fn != NULL);
+	if (!_cap_map_is_seeded) srand(time(NULL));
+	cap_map *map = (cap_map *)CAP_ALLOCATOR(cap_map, 1);
+	if (!map) return NULL;
+	map->_compare_fn = compare_fn;
+	map->_height = CAP_MAP_MAX_SKIPLIST_SIZE;
+	map->_size = 0;
+	map->_key_size = key_size;
+	return map;
+}
+
+static int cap_map_insert(cap_map *map, void *key, void *value) {
+	assert(map != NULL && key != NULL && value != NULL);
+	cap_map *current_node = map;
+	int current_level = map->_height - 1;
+	cap_map *previous[CAP_MAP_MAX_SKIPLIST_SIZE];
+	while (current_level >= 0) {
+		previous[current_level] = current_node;
+		if (current_node->_forward[current_level] == NULL) {
+			current_level--;
+		} else {
+			int cmp = map->_compare_fn(
+			    current_node->_forward[current_level]->_key, key);
+			if (cmp == 0) {
+				current_node->_forward[current_level]->_value =
+				    value;
+				return 0;
+			} else if (cmp > 0) {
+				current_level--;
+			} else {
+				current_node =
+				    current_node->_forward[current_level];
+			}
+		}
+	}
+	cap_map *new_node = (cap_map *)CAP_ALLOCATOR(cap_map, 1);
+	if (!new_node) return -1;
+	new_node->_value = value;
+	new_node->_key =
+	    (unsigned char *)CAP_ALLOCATOR(unsigned char, map->_key_size);
+	if (!new_node->_key) return -1;
+	memcpy(new_node->_key, key, map->_key_size);
+	new_node->_height = _cap_map_get_rand_level(map->_height);
+	new_node->_key_size = map->_key_size;
+	++map->_size;
+	for (int i = map->_height - 1; i > new_node->_height; --i)
+		new_node->_forward[i] = NULL;
+	for (int i = map->_height - 1; i >= 0; --i) {
+		new_node->_forward[i] = previous[i]->_forward[i];
+		previous[i]->_forward[i] = new_node;
+	}
+	return 0;
+}
+
+static void *cap_map_find(cap_map *map, void *key) {
+	assert(map != NULL && key != NULL);
+	cap_map *current_node;
+	int current_level = map->_height - 1;
+	while (current_level >= 0) {
+		if (current_node->_forward[current_level] == NULL) {
+			current_level--;
+		} else {
+			int cmp = map->_compare_fn(
+			    current_node->_forward[current_level]->_key, key);
+			if (cmp == 0) {
+				return current_node->_forward[current_level]
+				    ->_value;
+			} else if (cmp > 0) {
+				current_level--;
+			} else {
+				current_node =
+				    current_node->_forward[current_level];
+			}
+		}
+	}
+	return NULL;
+}
+
+static int cap_map_height(cap_map *map) {
+	assert(map != NULL);
+	return map->_height;
+}
+
+static bool cap_map_contains(cap_map *map, void *key) {
+	assert(map != NULL && key != NULL);
+	return cap_map_find(map, key) != NULL;
+}
+
+static int (*cap_map_compare_fn(cap_map *map))(void *, void *) {
+	assert(map != NULL);
+	return map->_compare_fn;
+}
+
+static size_t cap_map_size(cap_map *map) {
+	assert(map != NULL);
+	return map->_size;
+}
+
+static bool cap_map_empty(cap_map *map) {
+	assert(map != NULL);
+	return map->_size == 0;
+}
+
+static int cap_map_remove(cap_map *map, void *key) {
+	assert(map != NULL && key != NULL);
+	cap_map *current_node = map;
+	int current_level = map->_height - 1;
+	cap_map *previous[CAP_MAP_MAX_SKIPLIST_SIZE];
+	int cmp;
+	while (current_level >= 0) {
+		previous[current_level] = current_node;
+		if (current_node->_forward[current_level] == NULL) {
+			current_level--;
+		} else {
+			cmp = map->_compare_fn(
+			    current_node->_forward[current_level]->_key, key);
+			if (cmp >= 0) {
+				current_level--;
+			} else {
+				current_node =
+				    current_node->_forward[current_level];
+			}
+		}
+	}
+	if (!cmp) {
+		cap_map *node_to_remove = current_node->_forward[0];
+		for (int i = node_to_remove->_height; i >= 0; --i)
+			previous[i]->_forward[i] = node_to_remove->_forward[i];
+		_cap_map_free_node(node_to_remove);
+		map->_size--;
+		return 0;
+	}
+	return -1;
+}
+
+static void cap_map_free(cap_map *map) {
+	assert(map != NULL);
+	cap_map *free_me = map;
+	map = map->_forward[0];
+	for (int i = map->_height - 1; i >= 0; --i) {
+		_cap_map_free_node(free_me);
+		free_me = map;
+		map = map->_forward[0];
+	}
+}
+
+static void cap_map_deep_free(cap_map *map) {
+	assert(map != NULL);
+	cap_map *free_me = map;
+	map = map->_forward[0];
+	for (int i = map->_height - 1; i >= 0; --i) {
+		_cap_map_deep_free_node(free_me);
+		free_me = map;
+		map = map->_forward[0];
+	}
+}
+
+static int _cap_map_get_rand_level(int max_number) {
+	int returner = 1;
+	while (returner < max_number && (rand() > RAND_MAX / 2)) returner += 1;
+	return returner;
+}
+
+static void _cap_map_free_node(cap_map *map) {
+	if (map)
+		if (map->_key) free(map->_key);
+}
+
+static void _cap_map_deep_free_node(cap_map *map) {
+	if (map) {
+		if (map->_key) free(map->_key);
+		if (map->_value) free(map->_value);
+		free(map);
+	}
+}
+
+#endif // !CAP_MAP_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(
 	test-stack.c
 	test-forward-list.c
 	test-hash-table-separate-chaining.c
+	test-map.c
 )
 add_executable(
 	${PROJECT_NAME}

--- a/tests/test-main.c
+++ b/tests/test-main.c
@@ -7,6 +7,7 @@ extern void test_vector(void);
 extern void test_stack(void);
 extern void test_forward_list(void);
 extern void test_hash_table_separate_chain(void);
+extern void test_map(void);
 
 int main(int argc, const char *const argv[]) {
 	test_dynamic_queue();
@@ -16,6 +17,7 @@ int main(int argc, const char *const argv[]) {
 	test_stack();
 	test_forward_list();
 	test_hash_table_separate_chain();
+	test_map();
 
 	return 0;
 }

--- a/tests/test-map.c
+++ b/tests/test-map.c
@@ -1,0 +1,70 @@
+#include "internal/test-helper.h"
+#include <map.h>
+
+static int compare_fn_int(void *x, void *y) {
+	if (*(int *)x > *(int *)y)
+		return 1;
+	else if (*(int *)x < *(int *)y)
+		return -1;
+	return 0;
+}
+
+void test_map(void) {
+	{
+		cap_map *map = cap_map_init(sizeof(int), compare_fn_int);
+		CAP_ASSERT_EQ(cap_map_size(map), 0, "MAP size after init");
+		CAP_ASSERT_EQ(cap_map_height(map), CAP_MAP_MAX_SKIPLIST_SIZE,
+			      "MAP height after init");
+		CAP_ASSERT_TRUE(cap_map_empty(map),
+				"MAP empty check after init");
+		int key_one = 1;
+		float value_one = 10.0f;
+		CAP_ASSERT_EQ(cap_map_insert(map, &key_one, &value_one), 0,
+			      "MAP insert key one return");
+		int key_two = 2;
+		float value_two = 20.0f;
+		CAP_ASSERT_EQ(cap_map_insert(map, &key_two, &value_two), 0,
+			      "MAP insert key two return");
+		CAP_ASSERT_EQ(cap_map_size(map), 2,
+			      "MAP size after inserting two items");
+		int key_three = 3;
+		int key_four = 4;
+		int key_five = 5;
+		float value_three = 30.0f;
+		float value_four = 40.0f;
+		float value_five = 50.0f;
+		cap_map_insert(map, &key_three, &value_three);
+		cap_map_insert(map, &key_four, &value_four);
+		cap_map_insert(map, &key_five, &value_five);
+		int invalid_key = 99;
+		CAP_ASSERT_EQ(cap_map_remove(map, &invalid_key), -1,
+			      "MAP invalid key remove");
+		CAP_ASSERT_EQ(cap_map_size(map), 5,
+			      "MAP size after five insert, one invalid remove");
+		float *four_ptr = cap_map_find(map, &key_four);
+		CAP_ASSERT_TRUE(four_ptr != NULL && *four_ptr == value_four,
+				"MAP find four");
+		CAP_ASSERT_EQ(cap_map_remove(map, &key_four), 0,
+			      "MAP remove key four");
+		CAP_ASSERT_EQ(cap_map_remove(map, &key_four), -1,
+			      "MAP re-remove key four");
+		float *five_ptr = cap_map_find(map, &key_five);
+		CAP_ASSERT_TRUE(five_ptr != NULL && *five_ptr == value_five,
+				"MAP find key five");
+		float *two_ptr = cap_map_find(map, &key_two);
+		CAP_ASSERT_TRUE(two_ptr != NULL && *two_ptr == value_two,
+				"MAP find key two");
+		CAP_ASSERT_EQ(cap_map_remove(map, &key_two), 0,
+			      "MAP removed key two");
+		float *three_ptr = cap_map_find(map, &key_three);
+		CAP_ASSERT_TRUE(three_ptr != NULL && *three_ptr == value_three,
+				"MAP find key two");
+		CAP_ASSERT_FALSE(cap_map_contains(map, &key_two),
+				 "MAP contains on removed key, two");
+		CAP_ASSERT_TRUE(cap_map_contains(map, &key_one),
+				"MAP contains on key one");
+		CAP_ASSERT_FALSE(cap_map_empty(map),
+				 "MAP empty checks after operations");
+		cap_map_free(map);
+	}
+}


### PR DESCRIPTION
We used skip-list as the implementation method for the 'Sorted Key-Value
Pair' container. We could do this using a balanced tree, but that will
just add complexity and it's not worth it. Also, skip-list will be even
faster when compared to balanced tree. Need to write tests for this.